### PR TITLE
feat: introduce SQS batching for reprocessing files

### DIFF
--- a/src/reprocessMessage.ts
+++ b/src/reprocessMessage.ts
@@ -1,4 +1,4 @@
-import { S3BodySchema } from "./models/models";
+import { SendMessageBatchCommandOutput } from "@aws-sdk/client-sqs";
 import { log } from "./utilities/logger";
 import { ProducerService } from "./services/producerService";
 import { BucketService } from "./services/bucketService";
@@ -20,23 +20,42 @@ export async function reprocessMessage(
   }
 
   log.info(`S3 Key Path: ${s3KeyPath}`);
-  const s3Files = await bucketService.getS3Objects(bucketName, s3KeyPath || ""); // if s3KeyPath not found, reprocess the entire bucket
+  const s3Files = await bucketService.getS3Objects(bucketName, s3KeyPath || "");
   if (!s3Files || s3Files.length === 0) {
     throw s3NoObjectFoundError(`No object found for s3KeyPath ${s3KeyPath}`);
   }
 
   log.info(`Processing ${s3Files.length} items`);
-  await Promise.all(
-    s3Files.map((s3File) => {
-      const s3Body: S3BodySchema = {
-        Records: [
-          {
-            eventName: "ObjectCreated:Put",
-            s3: { object: { key: s3File } },
-          },
-        ],
-      };
-      return producerService.sendSqsMessage(queueUrl, s3Body);
-    }),
-  );
+
+  const BATCH_SIZE = 10;
+  const CONCURRENT_BATCHES = 30;
+
+  for (let i = 0; i < s3Files.length; i += BATCH_SIZE * CONCURRENT_BATCHES) {
+    const currentChunk = s3Files.slice(i, i + BATCH_SIZE * CONCURRENT_BATCHES);
+    const batchPromises: Array<Promise<SendMessageBatchCommandOutput>> = [];
+
+    for (let j = 0; j < currentChunk.length; j += BATCH_SIZE) {
+      const batch = currentChunk.slice(j, j + BATCH_SIZE);
+      const entries = batch.map((s3File, index) => ({
+        id: `msg_${i + j + index}`,
+        body: {
+          Records: [
+            {
+              eventName: "ObjectCreated:Put",
+              s3: { object: { key: s3File } },
+            },
+          ],
+        },
+      }));
+
+      batchPromises.push(
+        producerService.sendSqsMessageBatch(queueUrl, entries),
+      );
+    }
+
+    await Promise.all(batchPromises);
+    log.info(
+      `Progress: ${Math.min(i + currentChunk.length, s3Files.length)}/${s3Files.length}`,
+    );
+  }
 }

--- a/src/services/producerService.ts
+++ b/src/services/producerService.ts
@@ -1,6 +1,6 @@
 import {
-  SendMessageCommandOutput,
-  SendMessageCommand,
+  SendMessageBatchCommand,
+  SendMessageBatchCommandOutput,
   SQSClient,
 } from "@aws-sdk/client-sqs";
 import { log } from "../utilities/logger";
@@ -9,23 +9,25 @@ import { sqsSendMessageError } from "../utilities/errors";
 
 export const producerServiceBuilder = (sqsClient: SQSClient) => {
   return {
-    async sendSqsMessage(
+    async sendSqsMessageBatch(
       queueUrl: string,
-      messageBody: S3BodySchema,
-    ): Promise<SendMessageCommandOutput> {
+      entries: Array<{ id: string; body: S3BodySchema }>,
+    ): Promise<SendMessageBatchCommandOutput> {
       try {
-        const command: SendMessageCommand = new SendMessageCommand({
+        const command = new SendMessageBatchCommand({
           QueueUrl: queueUrl,
-          MessageBody: JSON.stringify(messageBody),
+          Entries: entries.map((entry) => ({
+            Id: entry.id,
+            MessageBody: JSON.stringify(entry.body),
+          })),
         });
-        const response: SendMessageCommandOutput =
-          await sqsClient.send(command);
-        return response;
+        return await sqsClient.send(command);
       } catch (error) {
-        log.error(`Error sending message`, error);
+        log.error(`Error sending message batch`, error);
         throw sqsSendMessageError(error);
       }
     },
   };
 };
+
 export type ProducerService = ReturnType<typeof producerServiceBuilder>;

--- a/test/reprocess.test.ts
+++ b/test/reprocess.test.ts
@@ -18,6 +18,7 @@ vi.mock("@aws-sdk/client-s3", () => ({
 vi.mock("@aws-sdk/client-sqs", () => ({
   SQSClient: vi.fn().mockImplementation(() => ({ send: vi.fn() })),
   SendMessageCommand: vi.fn(),
+  SendMessageBatchCommand: vi.fn(),
 }));
 
 import { reprocessMessage } from "../src/reprocessMessage";
@@ -46,52 +47,48 @@ describe("reprocessMessage tests", () => {
     ).rejects.toThrow(`No object found for s3KeyPath test-path`);
   });
 
-  it("calls sendSqsMessage for one file", async () => {
-    const sendSpy = vi
-      .spyOn(producerService, "sendSqsMessage")
+  it("calls sendSqsMessageBatch for one file", async () => {
+    const batchSpy = vi
+      .spyOn(producerService, "sendSqsMessageBatch")
       .mockResolvedValue({} as any);
     vi.spyOn(bucketService, "getS3Objects").mockResolvedValue(["single-file"]);
 
     await reprocessMessage(producerService, bucketService);
 
-    expect(sendSpy).toHaveBeenCalledTimes(1);
-    expect(sendSpy).toHaveBeenCalledWith("https://sqs.test-url.com/1234", {
-      Records: [
-        {
-          eventName: "ObjectCreated:Put",
-          s3: { object: { key: "single-file" } },
+    expect(batchSpy).toHaveBeenCalledTimes(1);
+    expect(batchSpy).toHaveBeenCalledWith("https://sqs.test-url.com/1234", [
+      {
+        id: "msg_0",
+        body: {
+          Records: [
+            {
+              eventName: "ObjectCreated:Put",
+              s3: { object: { key: "single-file" } },
+            },
+          ],
         },
-      ],
-    });
+      },
+    ]);
   });
 
-  it("calls sendSqsMessage n times if multiple files found", async () => {
-    const sendSpy = vi
-      .spyOn(producerService, "sendSqsMessage")
+  it("calls sendSqsMessageBatch with correct chunking", async () => {
+    const batchSpy = vi
+      .spyOn(producerService, "sendSqsMessageBatch")
       .mockResolvedValue({} as any);
-    vi.spyOn(bucketService, "getS3Objects").mockResolvedValue([
-      "fileA",
-      "fileB",
-      "fileC",
-    ]);
+
+    const files = Array.from({ length: 15 }, (_, i) => `file-${i}`);
+    vi.spyOn(bucketService, "getS3Objects").mockResolvedValue(files);
 
     await reprocessMessage(producerService, bucketService);
 
-    expect(sendSpy).toHaveBeenCalledTimes(3);
-    expect(sendSpy).toHaveBeenCalledWith("https://sqs.test-url.com/1234", {
-      Records: [
-        { eventName: "ObjectCreated:Put", s3: { object: { key: "fileA" } } },
-      ],
-    });
-    expect(sendSpy).toHaveBeenCalledWith("https://sqs.test-url.com/1234", {
-      Records: [
-        { eventName: "ObjectCreated:Put", s3: { object: { key: "fileB" } } },
-      ],
-    });
-    expect(sendSpy).toHaveBeenCalledWith("https://sqs.test-url.com/1234", {
-      Records: [
-        { eventName: "ObjectCreated:Put", s3: { object: { key: "fileC" } } },
-      ],
-    });
+    expect(batchSpy).toHaveBeenCalledTimes(2);
+
+    const firstCallArgs = batchSpy.mock.calls[0][1];
+    expect(firstCallArgs).toHaveLength(10);
+    expect(firstCallArgs[0].body.Records[0].s3.object.key).toBe("file-0");
+
+    const secondCallArgs = batchSpy.mock.calls[1][1];
+    expect(secondCallArgs).toHaveLength(5);
+    expect(secondCallArgs[0].body.Records[0].s3.object.key).toBe("file-10");
   });
 });


### PR DESCRIPTION
# Feat: introduce SQS batch reprocessing

## Summary
Optimized the S3 reprocessing flow to prevent **JavaScript heap out of memory** errors. The logic now uses a chunked batching strategy to handle large-scale datasets (500k+ files) safely and efficiently.

## Key Changes
* **SQS Batching:** Integrated `SendMessageBatchCommand` to process 10 messages per API request, significantly reducing network overhead.
* **Controlled Concurrency:** Replaced global `Promise.all` with a segmented chunking approach (`BATCH_SIZE` & `CONCURRENT_BATCHES`) to maintain a flat memory profile.
* **Memory Management:** Eliminated memory exhaustion by ensuring the producer logic only holds a small subset of messages in the event loop at any given time.